### PR TITLE
Wrong message shown in Loss adjustment

### DIFF
--- a/opensrp-path/src/main/java/org/smartregister/path/fragment/PathJsonFormFragment.java
+++ b/opensrp-path/src/main/java/org/smartregister/path/fragment/PathJsonFormFragment.java
@@ -412,14 +412,12 @@ public class PathJsonFormFragment extends JsonFormFragment {
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
         boolean balancecheck = true;
-        boolean isLossAdjustmentForm = false;
 
         if (item.getItemId() == com.vijay.jsonwizard.R.id.action_save) {
             JSONObject object = getStep("step1");
             try {
-                isLossAdjustmentForm = object.getString("title").contains("Stock Loss/Adjustment");
-                if (object.getString("title").contains("Stock Issued") || object.getString("title").contains("Stock Received") || isLossAdjustmentForm) {
-                    if (isLossAdjustmentForm) {
+                if (object.getString("title").contains("Stock Issued") || object.getString("title").contains("Stock Received") || object.getString("title").contains("Stock Loss/Adjustment")) {
+                    if (object.getString("title").contains("Stock Loss/Adjustment")) {
                         // First perform validation & then balanceCheck
                         if (presenter == null) return true;
 
@@ -445,8 +443,6 @@ public class PathJsonFormFragment extends JsonFormFragment {
             }
         }
         if (balancecheck) {
-            if (isLossAdjustmentForm)
-                return true;
             return super.onOptionsItemSelected(item);
         } else {
             final Snackbar snackbar = Snackbar

--- a/opensrp-path/src/main/java/org/smartregister/path/fragment/PathJsonFormFragment.java
+++ b/opensrp-path/src/main/java/org/smartregister/path/fragment/PathJsonFormFragment.java
@@ -412,12 +412,14 @@ public class PathJsonFormFragment extends JsonFormFragment {
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
         boolean balancecheck = true;
+        boolean isLossAdjustmentForm = false;
 
         if (item.getItemId() == com.vijay.jsonwizard.R.id.action_save) {
             JSONObject object = getStep("step1");
             try {
-                if (object.getString("title").contains("Stock Issued") || object.getString("title").contains("Stock Received") || object.getString("title").contains("Stock Loss/Adjustment")) {
-                    if (object.getString("title").contains("Stock Loss/Adjustment")) {
+                isLossAdjustmentForm = object.getString("title").contains("Stock Loss/Adjustment");
+                if (object.getString("title").contains("Stock Issued") || object.getString("title").contains("Stock Received") || isLossAdjustmentForm) {
+                    if (isLossAdjustmentForm) {
                         // First perform validation & then balanceCheck
                         if (presenter == null) return true;
 
@@ -443,6 +445,8 @@ public class PathJsonFormFragment extends JsonFormFragment {
             }
         }
         if (balancecheck) {
+            if (isLossAdjustmentForm)
+                return true;
             return super.onOptionsItemSelected(item);
         } else {
             final Snackbar snackbar = Snackbar


### PR DESCRIPTION
When date is not entered, the following message is shown

"Please make sure the balance is not less than zero."

It should be changed to a message that directs the user to enter the date

NOW:
Validation is done before balance check