### PR TITLE
Fix: date-picker not using previously selected date on open

### DIFF
--- a/opensrp-path/src/main/java/org/smartregister/path/fragment/AdvancedSearchFragment.java
+++ b/opensrp-path/src/main/java/org/smartregister/path/fragment/AdvancedSearchFragment.java
@@ -1204,7 +1204,7 @@ public class AdvancedSearchFragment extends BaseSmartRegisterFragment {
             if (view instanceof EditText) {
                 previouslySelectedDateString = ((EditText) view).getText().toString();
 
-                if (!previouslySelectedDateString.equals("") && previouslySelectedDateString.length() > 2) {
+                if (!("").equals(previouslySelectedDateString) && previouslySelectedDateString.length() > 2) {
                     try {
                         Date previouslySelectedDate = DateUtil.yyyyMMdd.parse(previouslySelectedDateString);
                         mcurrentDate.setTime(previouslySelectedDate);

--- a/opensrp-path/src/main/java/org/smartregister/path/fragment/AdvancedSearchFragment.java
+++ b/opensrp-path/src/main/java/org/smartregister/path/fragment/AdvancedSearchFragment.java
@@ -1210,7 +1210,6 @@ public class AdvancedSearchFragment extends BaseSmartRegisterFragment {
                         mcurrentDate.setTime(previouslySelectedDate);
                     } catch (ParseException e) {
                         e.printStackTrace();
-
                     }
                 }
             }

--- a/opensrp-path/src/main/java/org/smartregister/path/fragment/AdvancedSearchFragment.java
+++ b/opensrp-path/src/main/java/org/smartregister/path/fragment/AdvancedSearchFragment.java
@@ -47,6 +47,7 @@ import org.smartregister.path.domain.RegisterClickables;
 import org.smartregister.path.provider.AdvancedSearchClientsProvider;
 import org.smartregister.util.Utils;
 
+import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Collections;
@@ -1197,6 +1198,23 @@ public class AdvancedSearchFragment extends BaseSmartRegisterFragment {
         public void onClick(View view) {
             //To show current date in the datepicker
             Calendar mcurrentDate = Calendar.getInstance();
+
+            String previouslySelectedDateString = "";
+
+            if (view instanceof EditText) {
+                previouslySelectedDateString = ((EditText) view).getText().toString();
+
+                if (!previouslySelectedDateString.equals("") && previouslySelectedDateString.length() > 2) {
+                    try {
+                        Date previouslySelectedDate = DateUtil.yyyyMMdd.parse(previouslySelectedDateString);
+                        mcurrentDate.setTime(previouslySelectedDate);
+                    } catch (ParseException e) {
+                        e.printStackTrace();
+
+                    }
+                }
+            }
+
             int mYear = mcurrentDate.get(Calendar.YEAR);
             int mMonth = mcurrentDate.get(Calendar.MONTH);
             int mDay = mcurrentDate.get(Calendar.DAY_OF_MONTH);


### PR DESCRIPTION
Date pickers in forms created natively i.e. without Native JSON would use the current date irrespective of the previously chosen date on the EditText.