### PR TITLE
Fix Edit Registration Form fields not showing previous patient values

### DIFF
--- a/opensrp-path/src/main/java/org/smartregister/path/activity/ChildDetailTabbedActivity.java
+++ b/opensrp-path/src/main/java/org/smartregister/path/activity/ChildDetailTabbedActivity.java
@@ -530,12 +530,14 @@ public class ChildDetailTabbedActivity extends BaseActivity implements Vaccinati
                         JSONArray birthFacilityHierarchy = null;
                         String birthFacilityName = getValue(detailmaps, "Birth_Facility_Name", false);
 
-                        if (birthFacilityName != null && birthFacilityName.equalsIgnoreCase("other")) {
-                            birthFacilityHierarchy = new JSONArray();
-                            birthFacilityHierarchy.put(birthFacilityName);
-                        } else if (birthFacilityName != null) {
-                            birthFacilityHierarchy = JsonFormUtils.getOpenMrsLocationHierarchy(
-                                    getOpenSRPContext(), birthFacilityName);
+                        if (birthFacilityName != null) {
+                            if (birthFacilityName.equalsIgnoreCase("other")) {
+                                birthFacilityHierarchy = new JSONArray();
+                                birthFacilityHierarchy.put(birthFacilityName);
+                            } else {
+                                birthFacilityHierarchy = JsonFormUtils.getOpenMrsLocationHierarchy(
+                                        getOpenSRPContext(), birthFacilityName);
+                            }
                         }
 
                         if (birthFacilityHierarchy != null) {

--- a/opensrp-path/src/main/java/org/smartregister/path/activity/ChildDetailTabbedActivity.java
+++ b/opensrp-path/src/main/java/org/smartregister/path/activity/ChildDetailTabbedActivity.java
@@ -534,8 +534,9 @@ public class ChildDetailTabbedActivity extends BaseActivity implements Vaccinati
                             birthFacilityHierarchy = new JSONArray();
                             birthFacilityHierarchy.put(birthFacilityName);
                         } else {
+                            String birthFacilityId = JsonFormUtils.getOpenMrsLocationId(getOpenSRPContext(), birthFacilityName);
                             birthFacilityHierarchy = JsonFormUtils.getOpenMrsLocationHierarchy(
-                                    getOpenSRPContext(), birthFacilityName);
+                                    getOpenSRPContext(), birthFacilityId);
                         }
 
                         if (birthFacilityHierarchy != null) {

--- a/opensrp-path/src/main/java/org/smartregister/path/activity/ChildDetailTabbedActivity.java
+++ b/opensrp-path/src/main/java/org/smartregister/path/activity/ChildDetailTabbedActivity.java
@@ -533,10 +533,9 @@ public class ChildDetailTabbedActivity extends BaseActivity implements Vaccinati
                         if (birthFacilityName != null && birthFacilityName.equalsIgnoreCase("other")) {
                             birthFacilityHierarchy = new JSONArray();
                             birthFacilityHierarchy.put(birthFacilityName);
-                        } else {
-                            String birthFacilityId = JsonFormUtils.getOpenMrsLocationId(getOpenSRPContext(), birthFacilityName);
+                        } else if (birthFacilityName != null) {
                             birthFacilityHierarchy = JsonFormUtils.getOpenMrsLocationHierarchy(
-                                    getOpenSRPContext(), birthFacilityId);
+                                    getOpenSRPContext(), birthFacilityName);
                         }
 
                         if (birthFacilityHierarchy != null) {

--- a/opensrp-path/src/main/java/org/smartregister/path/activity/ChildDetailTabbedActivity.java
+++ b/opensrp-path/src/main/java/org/smartregister/path/activity/ChildDetailTabbedActivity.java
@@ -583,7 +583,7 @@ public class ChildDetailTabbedActivity extends BaseActivity implements Vaccinati
                     if (jsonObject.getString(JsonFormUtils.KEY).equalsIgnoreCase("Home_Facility")) {
                         JSONArray homeFacilityHierarchy = JsonFormUtils.getOpenMrsLocationHierarchy(
                                 getOpenSRPContext(), getValue(detailmaps,
-                                        "Home_Facility", true));
+                                        "Home_Facility", false));
                         if (homeFacilityHierarchy != null) {
                             jsonObject.put(JsonFormUtils.VALUE, homeFacilityHierarchy.toString());
                         }


### PR DESCRIPTION
The following field does not show the previous value in the edit form:
* Child's home health facility field

How to reproduce:

1. Chose a patient
2. Click on the top bar with basic patient details i.e Patient name, ZEIR ID, Age
3. Click on the edit icon > Edit registration data
