### PR TITLE
Fix Log-in-loading dialog called after activity destroyed

### DIFF
--- a/opensrp-path/src/main/java/org/smartregister/path/activity/LoginActivity.java
+++ b/opensrp-path/src/main/java/org/smartregister/path/activity/LoginActivity.java
@@ -521,8 +521,10 @@ public class LoginActivity extends AppCompatActivity {
         @Override
         protected void onPostExecute(LoginResponse loginResponse) {
             super.onPostExecute(loginResponse);
-            progressDialog.dismiss();
-            afterLoginCheck.onEvent(loginResponse);
+            if (!isDestroyed()) {
+                progressDialog.dismiss();
+                afterLoginCheck.onEvent(loginResponse);
+            }
         }
     }
 


### PR DESCRIPTION
For more https://github.com/OpenSRP/opensrp-client-path/issues/147