### PR TITLE
App crash on multiple button clicks

### DIFF
--- a/opensrp-path/src/main/java/org/smartregister/path/activity/ChildImmunizationActivity.java
+++ b/opensrp-path/src/main/java/org/smartregister/path/activity/ChildImmunizationActivity.java
@@ -95,7 +95,6 @@ import util.ImageUtils;
 import util.JsonFormUtils;
 import util.PathConstants;
 
-
 /**
  * Created by Jason Rogena - jrogena@ona.io on 16/02/2017.
  */
@@ -657,12 +656,14 @@ public class ChildImmunizationActivity extends BaseActivity
     }
 
     private void showWeightDialog(View view) {
-        FragmentTransaction ft = this.getFragmentManager().beginTransaction();
-        Fragment prev = this.getFragmentManager().findFragmentByTag(DIALOG_TAG);
+        FragmentManager fragmentManager = this.getFragmentManager();
+        RecordWeightDialogFragment prev = (RecordWeightDialogFragment) util.Utils.findDuplicateFragment(fragmentManager,
+                DIALOG_TAG, RecordWeightDialogFragment.class.getName());
         if (prev != null) {
-            Log.d("duplicate fragments", "duplicate weight fragments exist!");
             return;
         }
+
+        FragmentTransaction ft = fragmentManager.beginTransaction();
         ft.addToBackStack(null);
 
         String dobString = Utils.getValue(childDetails.getColumnmaps(), PathConstants.EC_CHILD_TABLE.DOB, false);
@@ -846,13 +847,14 @@ public class ChildImmunizationActivity extends BaseActivity
     }
 
     private void addServiceDialogFragment(ServiceWrapper serviceWrapper, ServiceGroup serviceGroup) {
-
-        FragmentTransaction ft = this.getFragmentManager().beginTransaction();
-        Fragment prev = this.getFragmentManager().findFragmentByTag(DIALOG_TAG);
+        FragmentManager fragmentManager = this.getFragmentManager();
+        Fragment prev = util.Utils.findDuplicateFragment(fragmentManager, DIALOG_TAG,
+                ServiceDialogFragment.class.getName());
         if (prev != null) {
-            ft.remove(prev);
+            return;
         }
 
+        FragmentTransaction ft = fragmentManager.beginTransaction();
         ft.addToBackStack(null);
         serviceGroup.setModalOpen(true);
 
@@ -1459,14 +1461,14 @@ public class ChildImmunizationActivity extends BaseActivity
         protected void onPreExecute() {
             super.onPreExecute();
             FragmentManager fragmentManager = ChildImmunizationActivity.this.getFragmentManager();
-            Fragment prev = fragmentManager.findFragmentByTag(DIALOG_TAG);
-            ft = fragmentManager.beginTransaction();
+            Fragment prev = util.Utils.findDuplicateFragment(fragmentManager, DIALOG_TAG,
+                    GrowthDialogFragment.class.getName());
             if (prev != null) {
-                Log.d("duplicate fragment", "found duplicate growth fragment"); // remove this
                 this.cancel(true);
                 return;
             }
-             // remove this comment
+
+            ft = fragmentManager.beginTransaction();
             showProgressDialog();
         }
 

--- a/opensrp-path/src/main/java/org/smartregister/path/activity/ChildImmunizationActivity.java
+++ b/opensrp-path/src/main/java/org/smartregister/path/activity/ChildImmunizationActivity.java
@@ -1,6 +1,7 @@
 package org.smartregister.path.activity;
 
 import android.app.Fragment;
+import android.app.FragmentManager;
 import android.app.FragmentTransaction;
 import android.content.ContentValues;
 import android.content.Context;
@@ -659,7 +660,7 @@ public class ChildImmunizationActivity extends BaseActivity
         FragmentTransaction ft = this.getFragmentManager().beginTransaction();
         Fragment prev = this.getFragmentManager().findFragmentByTag(DIALOG_TAG);
         if (prev != null) {
-            ft.remove(prev);
+            ft.remove(prev); // come back here
         }
         ft.addToBackStack(null);
 
@@ -1451,9 +1452,20 @@ public class ChildImmunizationActivity extends BaseActivity
     }
 
     private class ShowGrowthChartTask extends AsyncTask<Void, Void, List<Weight>> {
+        FragmentTransaction ft;
+
         @Override
         protected void onPreExecute() {
             super.onPreExecute();
+            FragmentManager fragmentManager = ChildImmunizationActivity.this.getFragmentManager();
+            Fragment prev = fragmentManager.findFragmentByTag(DIALOG_TAG);
+            ft = fragmentManager.beginTransaction();
+            if (prev != null) {
+                Log.d("duplicate fragment", "found duplicate fragment"); // remove this
+                this.cancel(true);
+                return;
+            }
+             // remove this comment
             showProgressDialog();
         }
 
@@ -1482,14 +1494,8 @@ public class ChildImmunizationActivity extends BaseActivity
         protected void onPostExecute(List<Weight> allWeights) {
             super.onPostExecute(allWeights);
             hideProgressDialog();
-            FragmentTransaction ft = ChildImmunizationActivity.this.getFragmentManager().beginTransaction();
-            Fragment prev = ChildImmunizationActivity.this.getFragmentManager().findFragmentByTag(DIALOG_TAG);
-            if (prev != null) {
-                ft.remove(prev);
-            }
+
             ft.addToBackStack(null);
-
-
             GrowthDialogFragment growthDialogFragment = GrowthDialogFragment.newInstance(childDetails, allWeights);
             growthDialogFragment.show(ft, DIALOG_TAG);
         }

--- a/opensrp-path/src/main/java/org/smartregister/path/activity/ChildImmunizationActivity.java
+++ b/opensrp-path/src/main/java/org/smartregister/path/activity/ChildImmunizationActivity.java
@@ -660,7 +660,8 @@ public class ChildImmunizationActivity extends BaseActivity
         FragmentTransaction ft = this.getFragmentManager().beginTransaction();
         Fragment prev = this.getFragmentManager().findFragmentByTag(DIALOG_TAG);
         if (prev != null) {
-            ft.remove(prev); // come back here
+            Log.d("duplicate fragments", "duplicate weight fragments exist!");
+            return;
         }
         ft.addToBackStack(null);
 
@@ -1461,7 +1462,7 @@ public class ChildImmunizationActivity extends BaseActivity
             Fragment prev = fragmentManager.findFragmentByTag(DIALOG_TAG);
             ft = fragmentManager.beginTransaction();
             if (prev != null) {
-                Log.d("duplicate fragment", "found duplicate fragment"); // remove this
+                Log.d("duplicate fragment", "found duplicate growth fragment"); // remove this
                 this.cancel(true);
                 return;
             }

--- a/opensrp-path/src/main/java/util/Utils.java
+++ b/opensrp-path/src/main/java/util/Utils.java
@@ -16,6 +16,8 @@
 
 package util;
 
+import android.app.Fragment;
+import android.app.FragmentManager;
 import android.content.Context;
 import android.content.res.Resources;
 import android.graphics.Color;
@@ -335,4 +337,25 @@ public class Utils {
         float px = TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, dp, r.getDisplayMetrics());
         return Math.round(px);
     }
+
+    public static Fragment findDuplicateFragment(FragmentManager fragmentManager, String tag, String className)
+            throws IllegalArgumentException {
+
+        if (fragmentManager == null || isEmptyStringOrNull(tag) || isEmptyStringOrNull(className)) {
+            throw new IllegalArgumentException("None of the function arguments can be null or empty!");
+        }
+
+        Fragment fragment = fragmentManager.findFragmentByTag(tag);
+        if (fragment == null) {
+            return null;
+        } else if (fragment.getClass().getName().equals(className)) {
+            return fragment;
+        }
+        return null;
+    }
+
+    public static boolean isEmptyStringOrNull(String s) {
+        return (s == null || s.equals(""));
+    }
 }
+


### PR DESCRIPTION
This bug can be reproduced by applying multiple, quick and successive clicks to the record weight button, the growth chart button or the service card labels - all in the Immunization activity.

At the moment, such clicks cause the app to crash.

This fix prevents multiple instances of the same dialog fragment-type from being opened if one already exists.

See more at #266 
