### PR TITLE
JSON forms in stock section changing after openning child enrollment form

### DIFF
--- a/opensrp-path/build.gradle
+++ b/opensrp-path/build.gradle
@@ -115,7 +115,7 @@ android {
 
 dependencies {
     compile fileTree(include: ['commons-validator-1.6.jar'], dir: 'libs')
-    compile('org.smartregister:opensrp-client-native-form:1.0.5-SNAPSHOT@aar') {
+    compile('org.smartregister:opensrp-client-native-form:1.0.7-SNAPSHOT@aar') {
         transitive = true
         exclude group: 'com.android.support', module: 'recyclerview-v7'
     }
@@ -133,7 +133,7 @@ dependencies {
         exclude group: 'org.smartregister', module: 'opensrp-client-core'
     }
 
-    compile('org.smartregister:opensrp-client-stock:1.0.0-SNAPSHOT@aar') {
+    compile('org.smartregister:opensrp-client-stock:1.0.2-SNAPSHOT@aar') {
         transitive = true
         exclude group: 'org.smartregister', module: 'opensrp-client-core'
         exclude group: 'org.smartregister', module: 'opensrp-client-native-form'

--- a/opensrp-path/src/main/java/org/smartregister/path/fragment/PathJsonFormFragment.java
+++ b/opensrp-path/src/main/java/org/smartregister/path/fragment/PathJsonFormFragment.java
@@ -81,7 +81,7 @@ public class PathJsonFormFragment extends JsonFormFragment {
 
     @Override
     protected JsonFormFragmentPresenter createPresenter() {
-        return new JsonFormFragmentPresenter(this, PathJsonFormInteractor.getInstance());
+        return new JsonFormFragmentPresenter(this, PathJsonFormInteractor.getPathInteractorInstance());
     }
 
     public Context context() {

--- a/opensrp-path/src/main/java/org/smartregister/path/interactors/PathJsonFormInteractor.java
+++ b/opensrp-path/src/main/java/org/smartregister/path/interactors/PathJsonFormInteractor.java
@@ -11,7 +11,7 @@ import org.smartregister.path.widgets.PathEditTextFactory;
  */
 public class PathJsonFormInteractor extends JsonFormInteractor {
 
-    private static final JsonFormInteractor INSTANCE = new PathJsonFormInteractor();
+    private static final JsonFormInteractor PATH_INTERACTOR_INSTANCE = new PathJsonFormInteractor();
 
     private PathJsonFormInteractor() {
         super();
@@ -24,7 +24,7 @@ public class PathJsonFormInteractor extends JsonFormInteractor {
         map.put(JsonFormConstants.DATE_PICKER, new PathDatePickerFactory());
     }
 
-    public static JsonFormInteractor getInstance() {
-        return INSTANCE;
+    public static JsonFormInteractor getPathInteractorInstance() {
+        return PATH_INTERACTOR_INSTANCE;
     }
 }


### PR DESCRIPTION

This was fixed by creating a different instance of JSONFormInteractor for non-stock forms
A small change was also made on the native forms to make a map, holding the form widget factories, non-static & non-final

See #331 