### PR TITLE
Switching a child's mother creates a new mother

### DIFF
--- a/opensrp-path/src/main/java/util/JsonFormUtils.java
+++ b/opensrp-path/src/main/java/util/JsonFormUtils.java
@@ -197,7 +197,7 @@ public class JsonFormUtils extends org.smartregister.util.JsonFormUtils {
             }
 
             if (StringUtils.isNotBlank(subBindType)) {
-                subFormClient = JsonFormUtils.createSubformClient(context, fields, baseClient, subBindType, relationalId);
+                subFormClient = JsonFormUtils.createSubformClient(context, fields, baseClient, subBindType, lookUpBaseEntityId);
             }
             Event se = null;
             if (subFormClient != null && e != null) {

--- a/opensrp-path/src/main/java/util/JsonFormUtils.java
+++ b/opensrp-path/src/main/java/util/JsonFormUtils.java
@@ -191,13 +191,9 @@ public class JsonFormUtils extends org.smartregister.util.JsonFormUtils {
                 lookUpBaseEntityId = getString(lookUpJSONObject, "value");
             }
 
-            if ("mother".equals(lookUpEntityId) && StringUtils.isNotBlank(lookUpBaseEntityId)) {
-                Client ss = new Client(lookUpBaseEntityId);
-                addRelationship(context, ss, baseClient);
-            }
-
             if (StringUtils.isNotBlank(subBindType)) {
-                subFormClient = JsonFormUtils.createSubformClient(context, fields, baseClient, subBindType, lookUpBaseEntityId);
+                String motherBaseEntityId = TextUtils.isEmpty(lookUpBaseEntityId) ? relationalId : lookUpBaseEntityId;
+                subFormClient = JsonFormUtils.createSubformClient(context, fields, baseClient, subBindType, motherBaseEntityId);
             }
             Event se = null;
             if (subFormClient != null && e != null) {


### PR DESCRIPTION
See more at #340 

Before:

1. Leads to multiple mothers with same name
2. The child ends up having multiple mothers in the `Client` doc > `relationships` > `mother` array

Now:

1. Duplicate mother is not created
2. The child ends up having one mother(related to one mother)  in the `Client` doc > `relationships` > `mother` array
